### PR TITLE
fix shape mismatch in division

### DIFF
--- a/projects/SparseRCNN/sparsercnn/loss.py
+++ b/projects/SparseRCNN/sparsercnn/loss.py
@@ -104,7 +104,7 @@ class SetCriterion(nn.Module):
         loss_giou = 1 - torch.diag(box_ops.generalized_box_iou(src_boxes, target_boxes))
         losses['loss_giou'] = loss_giou.sum() / num_boxes
 
-        image_size = torch.cat([v["image_size_xyxy_tgt"] for v in targets])
+        image_size = torch.cat([v["image_size_xyxy_tgt"][:self.cfg.MODEL.SparseRCNN.NUM_PROPOSALS] for v in targets])
         src_boxes_ = src_boxes / image_size
         target_boxes_ = target_boxes / image_size
 


### PR DESCRIPTION
Hi 大佬，

I found that a shape mismatch error will occur at ```
        src_boxes_ = src_boxes / image_size``` during loss computing, when training set containing images with number of detection targets larger than MODEL.SparseRCNN.NUM_PROPOSALS in cfg, since the shape pf image_size will be larger than shape of src_box in this case.
The error will look like
```
Traceback (most recent call last):
  File "/data/SparseR-CNN/projects/SparseRCNN/train_net.py", line 148, in <module>
    args=(args,),
  File "/data/SparseR-CNN/detectron2/engine/launch.py", line 62, in launch
    main_func(*args)
  File "/data/SparseR-CNN/projects/SparseRCNN/train_net.py", line 129, in main
    return trainer.train()
  File "/data/SparseR-CNN/detectron2/engine/defaults.py", line 419, in train
    super().train(self.start_iter, self.max_iter)
  File "/data/SparseR-CNN/detectron2/engine/train_loop.py", line 134, in train
    self.run_step()
  File "/data/SparseR-CNN/detectron2/engine/defaults.py", line 429, in run_step
    self._trainer.run_step()
  File "/data/SparseR-CNN/detectron2/engine/train_loop.py", line 228, in run_step
    loss_dict = self.model(data)
  File "/opt/conda/lib/python3.7/site-packages/torch/nn/modules/module.py", line 550, in __call__
    result = self.forward(*input, **kwargs)
  File "/data/SparseR-CNN/projects/SparseRCNN/sparsercnn/detector.py", line 143, in forward
    loss_dict = self.criterion(output, targets)
  File "/opt/conda/lib/python3.7/site-packages/torch/nn/modules/module.py", line 550, in __call__
    result = self.forward(*input, **kwargs)
  File "/data/SparseR-CNN/projects/SparseRCNN/sparsercnn/loss.py", line 160, in forward
    losses.update(self.get_loss(loss, outputs, targets, indices, num_boxes))
  File "/data/SparseR-CNN/projects/SparseRCNN/sparsercnn/loss.py", line 136, in get_loss
    return loss_map[loss](outputs, targets, indices, num_boxes, **kwargs)
  File "/data/SparseR-CNN/projects/SparseRCNN/sparsercnn/loss.py", line 109, in loss_boxes
    src_boxes_ = src_boxes / image_size
RuntimeError: The size of tensor a (21) must match the size of tensor b (63) at non-singleton dimension 0
```
so I think it might be necessary to limit the dimension of image_size at the maximum of cfg.MODEL.SparseRCNN.NUM_PROPOSALS. 

I created this PR in case you find it necessary.  