### PR TITLE
robust focal loss when alpah=-1

### DIFF
--- a/projects/SparseRCNN/sparsercnn/loss.py
+++ b/projects/SparseRCNN/sparsercnn/loss.py
@@ -246,8 +246,11 @@ class HungarianMatcher(nn.Module):
             # Compute the classification cost.
             alpha = self.focal_loss_alpha
             gamma = self.focal_loss_gamma
-            neg_cost_class = (1 - alpha) * (out_prob ** gamma) * (-(1 - out_prob + 1e-8).log())
-            pos_cost_class = alpha * ((1 - out_prob) ** gamma) * (-(out_prob + 1e-8).log())
+            neg_cost_class = (out_prob ** gamma) * (-(1 - out_prob + 1e-8).log())
+            pos_cost_class = ((1 - out_prob) ** gamma) * (-(out_prob + 1e-8).log())
+            if alpha >= 0:
+               neg_cost_class *= (1 - alpha)
+               pos_cost_class *= alpha
             cost_class = pos_cost_class[:, tgt_ids] - neg_cost_class[:, tgt_ids]
         else:
             cost_class = -out_prob[:, tgt_ids]


### PR DESCRIPTION
`alpha`: (optional) Weighting factor in range (0,1) to balance
positive vs negative examples. Default = -1 (no weighting).

Thanks for your contribution!

If you're sending a large PR (e.g., >50 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

We do not always accept features.
See https://detectron2.readthedocs.io/notes/contributing.html#pull-requests about how we handle PRs.

Before submitting a PR, please run `dev/linter.sh` to lint the code.

